### PR TITLE
Interrupts

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -1,7 +1,7 @@
 #define GNSS_RX 16
 #define GNSS_TX 17
-#define GNSS_PPS 19
-#define GNSS_EN 18
+#define GNSS_PPS 18
+#define GNSS_EN 19
 #define GNSS_EN_GPIO GPIO_NUM_18
 
 #define POWER_BTN 33

--- a/include/config.h
+++ b/include/config.h
@@ -2,7 +2,7 @@
 #define GNSS_TX 17
 #define GNSS_PPS 18
 #define GNSS_EN 19
-#define GNSS_EN_GPIO GPIO_NUM_18
+#define GNSS_EN_GPIO GPIO_NUM_19
 
 #define POWER_BTN 33
 #define POWER_BTN_GPIO GPIO_NUM_33

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,7 @@ void go_to_sleep() {
   power_off_display();
 
   // GNSS off.
-  digitalWrite(18, LOW);
+  digitalWrite(GNSS_EN, LOW);
 
   // Hold output pin states.
   gpio_hold_en(GNSS_EN_GPIO);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -227,6 +227,4 @@ void loop() {
       last_battery_percents = battery_percents;
     }
   }
-
-  delay(500);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@ NMEAParser parser;
 bool should_sleep = false;
 bool gps_is_ready = false;
 bool do_read_gnss = false;
+int  last_fix = 0;
 suseconds_t last_battery_read = 0;
 
 /**
@@ -44,6 +45,7 @@ void go_to_sleep() {
 void IRAM_ATTR read_gnss() {
   ets_printf("PPS triggered\n");
   do_read_gnss = true;
+  last_fix = millis();
 }
 
 /**
@@ -168,6 +170,12 @@ void loop() {
       } else {
         Serial.println("Failed parsing NMEA sentence.");
       }
+    }
+  } else {
+    int now = millis();
+    if (now > last_fix + 30 * 1000) {
+      draw_status("Waiting for GPS...");
+      draw_speed(0.0);
     }
   }
 


### PR DESCRIPTION
Use timers and interrupt on GNSS PPS pin to run routines and only draw on the display if there's a change. This should reduce power usage and make the display more responsive.